### PR TITLE
feat: Protect routes by default with a middleware

### DIFF
--- a/gestao_salas/settings.py
+++ b/gestao_salas/settings.py
@@ -48,6 +48,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'webapp.middleware.AuthRequiredMiddleware',
 ]
 
 ROOT_URLCONF = 'gestao_salas.urls'
@@ -126,6 +127,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 LOGIN_URL = '/login/'
 LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/login/'
+PUBLIC_URLS = ['/login/', '/register/', '/logout/']
 
 # Configurações de Mensagens
 MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'

--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -1,0 +1,8 @@
+def public_route(view_func):
+    """
+    Decorator to mark a view as public, exempting it from the global authentication check.
+    """
+    def wrapper(request, *args, **kwargs):
+        return view_func(request, *args, **kwargs)
+    wrapper.is_public = True
+    return wrapper

--- a/webapp/middleware.py
+++ b/webapp/middleware.py
@@ -1,0 +1,38 @@
+from django.conf import settings
+from django.shortcuts import redirect
+from django.urls import resolve, reverse
+from django.urls.exceptions import Resolver404
+
+class AuthRequiredMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # Resolve the view function
+        try:
+            view_func = resolve(request.path_info).func
+        except Resolver404:
+            # If the URL doesn't resolve, let Django handle it (e.g., show a 404 page)
+            return self.get_response(request)
+
+        # Check for authentication
+        if not request.user.is_authenticated:
+            # Allow access to public URLs defined in settings
+            if request.path_info in getattr(settings, 'PUBLIC_URLS', []):
+                return self.get_response(request)
+
+            # Allow access to views decorated with @public_route
+            if getattr(view_func, 'is_public', False):
+                return self.get_response(request)
+
+            # Allow access to static and media files
+            if settings.STATIC_URL and request.path_info.startswith(settings.STATIC_URL):
+                return self.get_response(request)
+
+            if getattr(settings, 'MEDIA_URL', None) and request.path_info.startswith(settings.MEDIA_URL):
+                return self.get_response(request)
+
+            # Redirect to login page if none of the above
+            return redirect(settings.LOGIN_URL)
+
+        return self.get_response(request)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -7,7 +7,9 @@ from django.contrib.auth.decorators import login_required
 from typing import Any
 import json
 from .models import Sala
+from .decorators import public_route
 
+@public_route
 def welcome(request: HttpRequest) -> HttpResponse:
     """View de boas-vindas para a aplicação de gestão de salas."""
     return render(request, 'webapp/welcome.html')
@@ -86,7 +88,6 @@ def user_register(request: HttpRequest) -> HttpResponse:
     return render(request, 'webapp/register.html', {'form': form})
 
 
-@login_required
 def dashboard(request: HttpRequest) -> HttpResponse:
     """View do dashboard (apenas para usuários autenticados)."""
     return render(request, 'webapp/dashboard.html')


### PR DESCRIPTION
Implements a middleware to enforce authentication on all routes.

Exempts public URLs (login, register, logout), static files, and views decorated with @public_route.

The welcome view is now public, and all other views are protected.