### PR TITLE
feat: Restrict create_admin_user to development environment

### DIFF
--- a/gestao_salas/settings.py
+++ b/gestao_salas/settings.py
@@ -11,9 +11,13 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+import os
+from dotenv import load_dotenv
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+load_dotenv()
 
 
 # Quick-start development settings - unsuitable for production

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Django==5.2.5
+python-dotenv==0.21.0

--- a/webapp/management/commands/create_admin_user.py
+++ b/webapp/management/commands/create_admin_user.py
@@ -2,12 +2,19 @@ from django.core.management.base import BaseCommand
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
 from typing import Optional
+import os
 
 
 class Command(BaseCommand):
     help = 'Creates an admin user with username guilherme.silveira and password 123456'
 
     def handle(self, *args: tuple, **options: dict) -> None:
+        if os.environ.get('DJANGO_ENV') != 'development':
+            self.stdout.write(self.style.ERROR(
+                'This command can only be run in the development environment.'
+            ))
+            return
+
         username = 'guilherme.silveira'
         password = '123456'
         


### PR DESCRIPTION
This commit restricts the `create_admin_user` management command to only run when the `DJANGO_ENV` environment variable is set to 'development'.

This is achieved by:
- Adding `python-dotenv` to manage environment variables.
- Configuring `settings.py` to load variables from a `.env` file.
- Modifying the `create_admin_user` command to check for the `DJANGO_ENV` variable before executing.